### PR TITLE
Flush only modified pages to disk

### DIFF
--- a/db/storage/pager.go
+++ b/db/storage/pager.go
@@ -45,7 +45,7 @@ func (p *Pager) FileLength() uint64 {
 
 func (p *Pager) FlushToDisk() {
 	for pageId, page := range p.pageCache {
-		if page != nil {
+		if page != nil && page.Dirty {
 			offset := int64(pageId * (RowsPerPage * RowSize))
 			_, err := p.file.WriteAt(SerializePage(page), offset)
 			if err != nil {
@@ -129,4 +129,5 @@ func (p *Pager) SaveAt(bytes [RowSize]byte, cursor *Cursor) {
 	}
 
 	page.Rows[cursor.RowNum%RowsPerPage] = &bytes
+	page.Dirty = true
 }

--- a/db/storage/table.go
+++ b/db/storage/table.go
@@ -17,7 +17,8 @@ const (
 )
 
 type Page struct {
-	Rows [RowsPerPage]*[RowSize]byte
+	Dirty bool
+	Rows  [RowsPerPage]*[RowSize]byte
 }
 
 type Row struct {
@@ -32,7 +33,9 @@ type Table struct {
 }
 
 func NewPage() *Page {
-	return &Page{Rows: [RowsPerPage]*[RowSize]byte{}}
+	return &Page{
+		Dirty: false,
+		Rows:  [RowsPerPage]*[RowSize]byte{}}
 }
 
 func Open(table string) *Table {


### PR DESCRIPTION
At the moment, the whole content of the database is written to a file on shutdown. After this change, the database will write only pages that were modified